### PR TITLE
Fix: "Add patient to queue" workspace not launching from patient search card

### DIFF
--- a/packages/esm-service-queues-app/src/patient-search/patient-search.workspace.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-search.workspace.tsx
@@ -1,29 +1,32 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SearchTypes } from '../types';
 import PatientScheduledVisits from './patient-scheduled-visits.component';
 import VisitForm from './visit-form/visit-form.component';
 import {
   type DefaultWorkspaceProps,
   ExtensionSlot,
+  Workspace2,
   usePatient,
   useVisit,
-  PatientBannerPatientInfo,
   PatientPhoto,
-  PatientBannerToggleContactDetailsButton,
-  PatientBannerContactDetails,
   displayName,
 } from '@openmrs/esm-framework';
 import ExistingVisitFormComponent from './visit-form/existing-visit-form.component';
 import styles from './patient-search.scss';
 
 interface PatientSearchProps extends DefaultWorkspaceProps {
-  viewState: {
+  viewState?: {
+    selectedPatientUuid?: string;
+  };
+  selectedPatientUuid?: string;
+  workspaceProps?: {
     selectedPatientUuid?: string;
   };
 }
 
-const PatientSearch: React.FC<PatientSearchProps> = ({ closeWorkspace, viewState }) => {
-  const { selectedPatientUuid } = viewState;
+const PatientSearch: React.FC<PatientSearchProps> = ({ closeWorkspace, viewState, selectedPatientUuid: propSelectedPatientUuid, workspaceProps }) => {
+  const selectedPatientUuid = propSelectedPatientUuid || viewState?.selectedPatientUuid || workspaceProps?.selectedPatientUuid;
   const { patient } = usePatient(selectedPatientUuid);
   const { activeVisit } = useVisit(selectedPatientUuid);
   const [searchType, setSearchType] = useState<SearchTypes>(SearchTypes.SCHEDULED_VISITS);
@@ -35,23 +38,20 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closeWorkspace, viewState
     setNewVisitMode(mode);
   };
 
+  const { t } = useTranslation();
   const patientName = patient && displayName(patient);
   return patient ? (
-    <>
+    <Workspace2 title={t('addPatientToQueue', 'Add patient to queue')}>
       <div className={styles.patientBannerContainer}>
-        <div className={styles.patientBanner}>
+        <div className={styles.patientBanner} style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '1rem' }}>
           <div className={styles.patientPhoto}>
             <PatientPhoto patientUuid={patient.id} patientName={patientName} />
           </div>
-          <PatientBannerPatientInfo patient={patient} />
-          <PatientBannerToggleContactDetailsButton
-            showContactDetails={showContactDetails}
-            toggleContactDetails={() => setContactDetails(!showContactDetails)}
-          />
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <span style={{ fontSize: '1.25rem', fontWeight: 600 }}>{patientName}</span>
+            <span>{patient.gender} &middot; {patient.birthDate}</span>
+          </div>
         </div>
-        {showContactDetails ? (
-          <PatientBannerContactDetails patientId={patient.id} deceased={patient.deceasedBoolean} />
-        ) : null}
       </div>
       <div>
         {activeVisit ? (
@@ -71,7 +71,7 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closeWorkspace, viewState
           />
         ) : null}
       </div>
-    </>
+    </Workspace2>
   ) : null;
 };
 

--- a/packages/esm-service-queues-app/src/patient-search/patient-search.workspace.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-search.workspace.tsx
@@ -5,7 +5,6 @@ import PatientScheduledVisits from './patient-scheduled-visits.component';
 import VisitForm from './visit-form/visit-form.component';
 import {
   type DefaultWorkspaceProps,
-  ExtensionSlot,
   Workspace2,
   usePatient,
   useVisit,


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.


## Description
This PR resolves an issue where clicking a patient card in the search results failed to launch the "Add patient to queue" child workspace (`service-queues-patient-search`). The issue presented as a lack of UI response, alongside several console errors. 

### Changes Made
- **Fixed `selectedPatientUuid` Resolution**: Updated `patient-search.workspace.tsx` to correctly extract `selectedPatientUuid` from `workspaceProps?.selectedPatientUuid`. Previously, it was causing an `Uncaught TypeError: Cannot read properties of undefined` when launched via `launchChildWorkspace`.
- **Resolved Extension Slot Collision**: Removed `<PatientBannerPatientInfo>` and `<PatientBannerContactDetails>` from the child workspace and replaced them with standard JSX. This resolves the `installHook.js:1` console warning (`An extension slot with the name 'patient-banner-bottom-slot' already exists`), which occurred because both the parent search result card and the child workspace were attempting to register the same extension slot simultaneously.
- **Added `<Workspace2>` Wrapper**: Wrapped the return output of `PatientSearch` in the `@openmrs/esm-framework` `<Workspace2>` component. Previously, the component was rendering a raw fragment (`<>...</>`), which caused it to mount invisibly in the DOM without the required visual modal/sliding panel UI. This aligns the implementation with how the original `create-queue-entry` works in the `openmrs-esm-patient-management` core app.


## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

https://github.com/user-attachments/assets/02a364ac-6c38-413b-894c-7e02e0fb89a6


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
