### PR TITLE
fix(billing): resolve 400/500 API errors on bill fetches and fix payment modes dashboard crash

### DIFF
--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -37,7 +37,6 @@ export const mapBillProperties = (bill: PatientInvoice): MappedBill => {
     lineItems: bill?.lineItems,
     billingService: bill?.lineItems.map((bill) => bill?.item || bill?.billableService || '--').join('  '),
     payments: bill?.payments,
-    display: bill?.display,
     totalAmount: bill?.lineItems?.map((item) => item.price * item.quantity).reduce((prev, curr) => prev + curr, 0),
   };
 

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -53,7 +53,8 @@ export const useBills = (
   const startingDateISO = startingDate.toISOString();
   const endDateISO = endDate.toISOString();
 
-  const url = `${restBaseUrl}/billing/bill?status=${billStatus}&v=custom:(uuid,display,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
+  const statusParam = billStatus ? `status=${billStatus}&` : '';
+  const url = `${restBaseUrl}/billing/bill?${statusParam}v=custom:(uuid,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
     patientUuid ? `${url}&patientUuid=${patientUuid}` : url,

--- a/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.component.tsx
+++ b/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.component.tsx
@@ -69,10 +69,6 @@ const PaymentModeDashboard: React.FC<PaymentModeDashboardProps> = () => {
 
   const headers = [
     {
-      key: 'dateCreated',
-      header: t('dateCreated', 'Date Created'),
-    },
-    {
       key: 'name',
       header: t('name', 'Name'),
     },
@@ -90,11 +86,6 @@ const PaymentModeDashboard: React.FC<PaymentModeDashboardProps> = () => {
     id: `${paymentMode.uuid}`,
     name: paymentMode.name,
     description: paymentMode.description,
-    dateCreated: formatDate(new Date(paymentMode.auditInfo.dateCreated), {
-      mode: 'standard',
-      time: false,
-      noToday: true,
-    }),
     retired: paymentMode.retired ? t('yes', 'Yes') : t('no', 'No'),
   }));
 

--- a/packages/esm-procedure-app/src/hooks/useBilling.ts
+++ b/packages/esm-procedure-app/src/hooks/useBilling.ts
@@ -32,7 +32,6 @@ export const mapBillProperties = (bill: PatientInvoice): MappedBill => {
         lineItems: bill?.lineItems,
         billingService: bill?.lineItems.map((bill) => bill?.item || bill?.billableService || '--').join('  '),
         payments: bill?.payments,
-        display: bill?.display,
         totalAmount: bill?.lineItems?.map((item) => item.price * item.quantity).reduce((prev, curr) => prev + curr, 0),
     };
 
@@ -48,7 +47,8 @@ export const useBills = (
     const startingDateISO = startingDate.toISOString();
     const endDateISO = endDate.toISOString();
 
-    const url = `${restBaseUrl}/billing/bill?status=${billStatus}&v=custom:(uuid,display,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
+    const statusParam = billStatus ? `status=${billStatus}&` : '';
+    const url = `${restBaseUrl}/billing/bill?${statusParam}v=custom:(uuid,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
 
     const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
         patientUuid ? `${url}&patientUuid=${patientUuid}` : url,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

This PR addresses several critical API and runtime errors in the `@openmrs/esm-billing-app` relating to fetching bills and rendering payment modes. 
### Changes Made
* **Fix 400 Bad Request on Bill Fetch**: The `useBills` hook was sending an empty `status=` query parameter (e.g., `?status=&v=custom...`) when no status filter was selected. The OpenMRS backend expects this field to map to a `PaymentStatus` Enum and throws a validation error when it receives an empty string. The hook now dynamically omits the parameter when empty.
* **Fix 500 Internal Server Error on Custom Representation**: Removed the `display` field from the root of the custom API query representation in `useBills`. The Java model (`org.openmrs.module.billing.api.model.Bill`) doesn't have a `display` property, which caused a `NoSuchMethodException` and `ConversionException` on the backend.
* **Fix Payment Mode Dashboard Crash**: The dashboard previously crashed with `TypeError: Cannot read properties of undefined (reading 'dateCreated')`. The OpenMRS backend REST API for Payment Modes (`?v=full`) does not return `auditInfo` or `dateCreated` fields. 
* **Remove Date Created Column**: Since the `dateCreated` field is entirely unavailable from the API for Payment Modes, the "Date Created" column has been removed from the Payment Modes data table to prevent rendering blank (`--`) columns and avoid confusion.
### Related Issues
* Fixes failing Bill metrics and Bill list views in the Billing Overview.
* Fixes white-screen crash on the Payment Modes admin dashboard.
* Fixes the procedure Bill url aswell
## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->
### Before 
<img width="1666" height="968" alt="Screenshot 2026-07-03 at 4 40 47 AM" src="https://github.com/user-attachments/assets/bcdcd384-290e-483e-a7a8-490194acd8f0" />
### After
<img width="1666" height="968" alt="Screenshot 2026-07-03 at 4 41 02 AM" src="https://github.com/user-attachments/assets/075e9453-a719-41ff-9e19-0057c0446975" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
