### PR TITLE
Fix billing payment processing and receipt printing

### DIFF
--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -84,7 +84,7 @@ export const useBills = (
 };
 
 export const useBill = (billUuid: string) => {
-  const url = `${apiBasePath}bill/${billUuid}`;
+  const url = `${apiBasePath}bill/${billUuid}?v=full`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PatientInvoice }>(
     billUuid ? url : null,
     openmrsFetch,
@@ -135,12 +135,15 @@ export const processBillPayment = (payload, billUuid: string) => {
 };
 
 export function useDefaultFacility() {
-  const url = `${restBaseUrl}/kenyaemr/default-facility`;
-  const { authenticated } = useSession();
+  const { sessionLocation } = useSession();
 
-  const { data, isLoading } = useSWR<{ data: FacilityDetail }>(authenticated ? url : null, openmrsFetch);
-
-  return { data: data?.data, isLoading: isLoading };
+  return {
+    data: {
+      uuid: sessionLocation?.uuid,
+      display: sessionLocation?.display || 'Facility',
+    },
+    isLoading: false,
+  };
 }
 
 export const usePatientPaymentInfo = (patientUuid: string) => {

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -138,11 +138,13 @@ export function useDefaultFacility() {
   const { sessionLocation } = useSession();
 
   return {
-    data: {
-      uuid: sessionLocation?.uuid,
-      display: sessionLocation?.display || 'Facility',
-    },
-    isLoading: false,
+    data: sessionLocation
+      ? {
+          uuid: sessionLocation.uuid,
+          display: sessionLocation.display || 'Facility',
+        }
+      : null,
+    isLoading: !sessionLocation,
   };
 }
 

--- a/packages/esm-billing-app/src/invoice/invoice.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice.component.tsx
@@ -116,7 +116,7 @@ const Invoice: React.FC = () => {
             size="md">
             {t('printBill', 'Print bill')}
           </Button>
-          {(bill?.status === 'PAID' || bill?.tenderedAmount > 0) && <PrintReceipt billId={bill?.id} />}
+          {(bill?.status === 'PAID' || bill?.tenderedAmount > 0) && <PrintReceipt billUuid={bill?.uuid} receiptNumber={bill?.receiptNumber} />}
         </div>
       </div>
 

--- a/packages/esm-billing-app/src/invoice/invoice.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice.component.tsx
@@ -116,7 +116,9 @@ const Invoice: React.FC = () => {
             size="md">
             {t('printBill', 'Print bill')}
           </Button>
-          {(bill?.status === 'PAID' || bill?.tenderedAmount > 0) && <PrintReceipt billUuid={bill?.uuid} receiptNumber={bill?.receiptNumber} />}
+          {bill && (bill.status === 'PAID' || bill.tenderedAmount > 0) && (
+            <PrintReceipt billUuid={bill.uuid} receiptNumber={bill.receiptNumber} />
+          )}
         </div>
       </div>
 

--- a/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
@@ -15,7 +15,7 @@ import PaymentHistory from './payment-history/payment-history.component';
 import PaymentForm from './payment-form/payment-form.component';
 import { updateBillVisitAttribute } from './payment.resource';
 import styles from './payments.scss';
-import { useBillableServices } from '../../billable-services/billable-service.resource';
+
 
 type PaymentProps = {
   bill: MappedBill;
@@ -31,7 +31,7 @@ export type PaymentFormValue = {
 
 const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) => {
   const { t } = useTranslation();
-  const { billableServices, isLoading, isValidating, error } = useBillableServices();
+
   const paymentSchema = z.object({
     method: z.string().refine((value) => !!value, 'Payment method is required'),
     amount: z
@@ -71,7 +71,6 @@ const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) =
         bill?.patientUuid,
         formValues,
         amountDue,
-        billableServices,
         selectedLineItems,
       );
       paymentPayload.payments.forEach((payment) => {

--- a/packages/esm-billing-app/src/invoice/payments/utils.ts
+++ b/packages/esm-billing-app/src/invoice/payments/utils.ts
@@ -40,9 +40,7 @@ export const createPaymentPayload = (
   const totalAmountRendered = updatedPayments.reduce((acc, payment) => acc + payment.amountTendered, 0);
 
   const updatedLineItems = bill?.lineItems.map((lineItem) => ({
-    ...lineItem,
-    billableService: getBillableServiceUuid(billableServices, lineItem.billableService),
-    item: processBillItem?.(lineItem),
+    uuid: lineItem.uuid,
     paymentStatus:
       bill?.lineItems.length > 1
         ? hasLineItem(selectedLineItems ?? [], lineItem) && totalAmountRendered >= lineItem.price * lineItem.quantity

--- a/packages/esm-billing-app/src/invoice/payments/utils.ts
+++ b/packages/esm-billing-app/src/invoice/payments/utils.ts
@@ -14,7 +14,6 @@ export const createPaymentPayload = (
   patientUuid: string,
   formValues: Array<Payment>,
   amountDue: number,
-  billableServices: Array<any>,
   selectedLineItems: Array<LineItem>,
 ) => {
   const { cashier } = bill;
@@ -67,4 +66,3 @@ export const createPaymentPayload = (
 export const getBillableServiceUuid = (billableServices: Array<any>, serviceName: string) => {
   return billableServices.length ? billableServices.find((service) => service.name === serviceName).uuid : null;
 };
-const processBillItem = (item) => (item.item || item.billableService)?.split(':')[0];

--- a/packages/esm-billing-app/src/invoice/printable-invoice/print-receipt.component.tsx
+++ b/packages/esm-billing-app/src/invoice/printable-invoice/print-receipt.component.tsx
@@ -6,9 +6,10 @@ import styles from './print-receipt.scss';
 import { apiBasePath } from '../../constants';
 
 interface PrintReceiptProps {
-  billId: number;
+  billUuid: string;
+  receiptNumber: string;
 }
-const PrintReceipt: React.FC<PrintReceiptProps> = ({ billId }) => {
+const PrintReceipt: React.FC<PrintReceiptProps> = ({ billUuid, receiptNumber }) => {
   const { t } = useTranslation();
   const [isRedirecting, setIsRedirecting] = useState(false);
   const baseUrl = new URL(window.location.href);
@@ -16,10 +17,10 @@ const PrintReceipt: React.FC<PrintReceiptProps> = ({ billId }) => {
   const handlePrintReceiptClick = () => {
     setIsRedirecting(true);
     setTimeout(() => {
-      const pdfUrl = `${baseUrl.origin}/openmrs${apiBasePath}receipt?billId=${billId}`;
+      const pdfUrl = `${baseUrl.origin}/openmrs${apiBasePath}receipt?billUuid=${billUuid}`;
       const link = document.createElement('a');
       link.href = pdfUrl;
-      link.download = `receipt_${billId}.pdf`;
+      link.download = `receipt_${receiptNumber}.pdf`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/packages/esm-billing-app/src/invoice/printable-invoice/print-receipt.component.tsx
+++ b/packages/esm-billing-app/src/invoice/printable-invoice/print-receipt.component.tsx
@@ -17,10 +17,11 @@ const PrintReceipt: React.FC<PrintReceiptProps> = ({ billUuid, receiptNumber }) 
   const handlePrintReceiptClick = () => {
     setIsRedirecting(true);
     setTimeout(() => {
-      const pdfUrl = `${baseUrl.origin}/openmrs${apiBasePath}receipt?billUuid=${billUuid}`;
+      const encodedBillUuid = encodeURIComponent(billUuid);
+      const pdfUrl = `${baseUrl.origin}/openmrs${apiBasePath}receipt?billUuid=${encodedBillUuid}`;
       const link = document.createElement('a');
       link.href = pdfUrl;
-      link.download = `receipt_${receiptNumber}.pdf`;
+      link.download = `receipt_${receiptNumber || billUuid}.pdf`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes two critical bugs in the billing module that prevented processing payments and printing receipts.

## Fix payment processing — `UnchangeableObjectException`
**Problem:** Processing a payment on a bill failed with a `500 Internal Server Error`:
> `org.openmrs.api.UnchangeableObjectException: Editing the fields [price] on BillLineItem is not allowed`
The `createPaymentPayload` function was spreading the full `lineItem` object (including immutable fields like `price` and `quantity`) into the update request. The backend's `ImmutableBillLineItemInterceptor` rejected the request because it detected those fields as "changed" even if the values were identical.
**Fix:** Modified `utils.ts` to only include `uuid` and `paymentStatus` in the `lineItems` array sent to the server, preventing Hibernate from triggering dirty checks on immutable fields.
---
## Commit 2: Fix receipt printing — `undefined` filename and failed download
**Problem:** Clicking "Print receipt" downloaded a file named `receipt_undefined.pdf` that contained no data (`Failed - No file`). Two root causes:
> 1. **Missing bill data:** `useBill` fetched the bill without `?v=full`, so the OpenMRS REST API returned the default representation which omits fields like `payments` and `id`. This caused `tenderedAmount` to calculate as `0` (hiding the Print receipt button) and `bill.id` to be `undefined`.
> 2. **Wrong receipt endpoint parameter:** The component used `?billId=${billId}` (numeric DB ID) but the OpenMRS billing module expects `?billUuid=${billUuid}`. The numeric `id` is never exposed by the REST API regardless of representation.
> 3. **Removed `kenyaemr` dependency:** `useDefaultFacility` was fetching from `/kenyaemr/default-facility` which doesn't exist without the KenyaEMR module. Replaced with a direct read from `sessionLocation`.
**Fix:**
- Added `?v=full` to the `useBill` fetch URL to ensure `payments` and all nested fields are returned
- Switched `PrintReceipt` component to accept `billUuid` and `receiptNumber` props (matching upstream openmrs-esm-billing-app)
- Changed the receipt endpoint URL from `?billId=` to `?billUuid=`
- Changed download filename to use `receiptNumber` instead of the unavailable numeric `id`
- Simplified `useDefaultFacility` to return `sessionLocation` directly without a network request
### Files changed
- `packages/esm-billing-app/src/billing.resource.ts`
- `packages/esm-billing-app/src/invoice/invoice.component.tsx`
- `packages/esm-billing-app/src/invoice/printable-invoice/print-receipt.component.tsx`

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->
### Before
<img width="1666" height="968" alt="Screenshot 2026-07-03 at 4 05 43 PM" src="https://github.com/user-attachments/assets/633c5c1f-af26-436d-815d-f44ffc5ab55d" />

### After
<img width="1666" height="968" alt="Screenshot 2026-07-03 at 4 06 00 PM" src="https://github.com/user-attachments/assets/1b3eead5-4437-4fdb-965f-0809ef4404b3" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->
https://intellisoftkenya.atlassian.net/browse/SJT-238
## Other
<!-- Anything not covered above -->
<!-- *None* -->
